### PR TITLE
Add support for using zip files on mac/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
     -i --info-plist <path>          Path to Info.plist file (required when packaging for macOS)
     -c --icns <path>                Path to .icns file (required when packaging for macOS)
     -e --executable <name>          Name of the executable file to set as executable.
+    -z --zip                        Use zip for packaging instead of tar.gz (only for Linux and MacOS)
     -v --verbose                    Enable verbose output
     -h --help                       Show this help message
 

--- a/README.md
+++ b/README.md
@@ -83,30 +83,6 @@ Examples:
 > If both are specified, then a universal build will be created.
 >
 > When executing just `monopack` on a macOS, a universal build is selected by default.
-
-> [!IMPORTANT]
-> If you are packaging for Linux or macOS from Windows, a message will be output in the console to inform you that you will need to manually apply the executable permissions on the Linux or macOS system once the archive is extracted to them.
->
-> ```sh
-> --------
-> Warning: Building for Linux on Windows.
-> Perform the following once the archive has been extracted on Linux to make it executable:
->    1. Open a terminal in the directory where the archive was unpacked to.
->    2. Execute the command "chmod +x ./ExampleGame"
->--------
-> ```
->
-> ```sh
-> --------
-> Warning: Building for macOS on Windows.
-> Perform the following once the archive has been extracted on macOs to make it executable:
->    1. Open a terminal in the directory where the archive was unpacked to.
->    2. Execute the command "chmod +x ./ExampleGame.app/Contents/MacOS/ExampleGame"
-> --------
-> ```
->
-> This is because Windows does not have an equivalent of `chmod` or the concept of a file being executable or not, so that file attribute cannot be set on a Windows system.
->
 > When possible, you should package them on their intended system, such as through GitHub Actions if you don't have access to them yourself.
 
 ## Required Files for macOS

--- a/src/ShyFox.MonoPack/Program.cs
+++ b/src/ShyFox.MonoPack/Program.cs
@@ -201,26 +201,6 @@ void PackageLinux()
         File.Delete(tarPath);
     }
 
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-        Console.WriteLine(
-            $"""
-
-            --------
-            Warning: Building for Linux on Windows.
-            Perform the following once the archive has been extracted on Linux to make it executable:
-                1. Open a terminal in the directory where the archive was unpacked to.
-                2. Execute the command "chmod +x ./{_executableFile ?? projectName}"
-            --------
-
-            """
-        );
-    }
-    else
-    {
-        Chmod(Path.Combine(sourceDir, _executableFile ?? projectName));
-    }
-
     using FileStream fs = new(tarPath, FileMode.Create, FileAccess.Write);
     if (_useZip)
     {
@@ -271,27 +251,6 @@ void PackageOSXIntel()
         Directory.Delete(contentsResourceDir, recursive: true);
     }
     Directory.Move(gameContentDir, contentsResourceDir);
-
-    // Set file as executable. Only works on Linux and mac
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-        Console.WriteLine(
-            $"""
-
-            --------
-            Warning: Building for macOS on Windows.
-            Perform the following once the archive has been extracted on macOs to make it executable:
-                1. Open a terminal in the directory where the archive was unpacked to.
-                2. Execute the command "chmod +x ./{_executableFile ?? projectName}.app/Contents/MacOS/{_executableFile ?? projectName}"
-            --------
-
-            """
-        );
-    }
-    else
-    {
-        Chmod(Path.Combine(sourceDir, _executableFile ?? projectName));
-    }
 
     string tarPath = Path.Combine(_outputDir, $"{_executableFile ?? projectName}-{OSX_X64_RID}.{(_useZip ? "zip" : "tar.gz")}");
 
@@ -352,27 +311,6 @@ void PackageOSXAppleSilicon()
         Directory.Delete(contentsResourceDir, recursive: true);
     }
     Directory.Move(gameContentDir, contentsResourceDir);
-
-    // Set file as executable. Only works on Linux and mac
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-        Console.WriteLine(
-            $"""
-
-            --------
-            Warning: Building for macOS on Windows.
-            Perform the following once the archive has been extracted on macOs to make it executable:
-                1. Open a terminal in the directory where the archive was unpacked to.
-                2. Execute the command "chmod +x ./{_executableFile ?? projectName}.app/Contents/MacOS/{_executableFile ?? projectName}"
-            --------
-
-            """
-        );
-    }
-    else
-    {
-        Chmod(Path.Combine(sourceDir, _executableFile ?? projectName));
-    }
 
     string tarPath = Path.Combine(_outputDir, $"{_executableFile ?? projectName}-{OSX_X64_RID}.{(_useZip ? "zip" : "tar.gz")}");
 
@@ -483,27 +421,6 @@ void PackageOSXUniversal()
         // Replace Windows (CRLF) line endings with Unix (LF) line endings
         scriptContent = scriptContent.ReplaceLineEndings("\n");
         File.WriteAllText(launchScriptPath, scriptContent);
-    }
-
-    // Set file as executable. Only works on Linux and mac
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-        Console.WriteLine(
-            $"""
-
-            --------
-            Warning: Building for macOS on Windows.
-            Perform the following once the archive has been extracted on macOs to make it executable:
-                1. Open a terminal in the directory where the archive was unpacked to.
-                2. Execute the command "chmod +x ./{_executableFile ?? projectName}.app/Contents/MacOS/{_executableFile ?? projectName}"
-            --------
-
-            """
-        );
-    }
-    else
-    {
-        Chmod(Path.Combine(macOSDir, _executableFile ?? projectName));
     }
 
     string tarPath = Path.Combine(_outputDir, $"{_executableFile ?? projectName}-universal.{(_useZip ? "zip" : "tar.gz")}");


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description

Update the app so that we can create a zip file for mac and linux builder. This helps when uploading to sites like itch.io which prefer zip files. 
The issue around execute permissions has been resolved by making use of the ExternalAttributes property on the ZipArchiveEntry. This allows use to set the *nix permissions directly when creating the entry. The target system will 
use that data when extracting the files. 

This permissions system works when using both .tar and .zip files.

## Related Issue Ticket Numbers
