### PR TITLE
Fix packaging issues with executable naming and permissions

### DIFF
--- a/src/MonoPack/MonoPack.csproj
+++ b/src/MonoPack/MonoPack.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <IsPackable>true</IsPackable>
     <PackageId>MonoPack</PackageId>
     <PackAsTool>true</PackAsTool>

--- a/src/MonoPack/Packagers/PlatformPackager.cs
+++ b/src/MonoPack/Packagers/PlatformPackager.cs
@@ -124,7 +124,10 @@ internal abstract class PlatformPackager : IPlatformPackager
                 permissions |= UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
             }
 
-            entry.ExternalAttributes = (int)permissions << 16;
+            // Need to add S_IFREG (regular file) so that the permissions
+            // are preserved when building on windows for mac/linux
+            int unixFileMode = (int)permissions | 0x8000;
+            entry.ExternalAttributes = unixFileMode << 16;
         }
     }
 


### PR DESCRIPTION
PR TITLE:
Fix packaging issues with executable naming, macOS archives, and Unix permissions

PR DESCRIPTION:
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description

This PR fixes several critical bugs discovered during cross-platform packaging with MonoPack:

### 1. NuGet Ambiguous Project Name Error
**Problem:** When using the `-e/--executable` option with names containing periods (e.g., `AutoPong.DesktopGL`) that match or are similar to the project name, NuGet throws an "Ambiguous project name" error during build.

**Solution:** Removed the `-p:AssemblyName` MSBuild parameter that was causing the conflict. Instead, executables are now renamed post-build using `File.Move()`, avoiding NuGet's project resolution entirely.

### 2. macOS Archives Including Previous Platform Packages
**Problem:** When building multiple runtime identifiers sequentially (e.g., win-x64, linux-x64, osx-x64), the macOS packages were including all previously created zip archives. This occurred because the `.app` bundle was created in the output directory, and when archiving with `includeBaseDirectory=true`, it would go up one level and include everything in the output directory.

**Solution:** Changed both `MacOSPackager` and `UniversalMacOSPackager` to create the `.app` bundle in a temporary directory before archiving. This ensures only the `.app` bundle is included in the archive.

### 3. Missing Content Directory Crash
**Problem:** Projects without MonoGame content files (no `.mgcb` references) would crash when the packager attempted to move a non-existent Content directory.

**Solution:** Added existence checks before attempting to move Content directories in macOS packagers.

### 4. Execute Permissions Not Preserved in Zip Files
**Problem:** When building zip files on Windows and extracting them on macOS/Linux, the execute permissions were lost. Users had to manually run `chmod +x` on the executable after extraction.

**Solution:** Unix file modes consist of both file type bits and permission bits. The code was only setting permission bits. Now includes `S_IFREG` (0x8000, regular file) along with permission bits in zip external attributes, which Unix unzip tools require to properly recognize and apply the permissions.

## Related Issue Ticket Numbers
- None