### PR TITLE
Allow user to specify publish args

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <NeutralLanguage>en</NeutralLanguage>
         <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
     -z --zip                        Use zip for packaging instead of tar.gz (only for Linux and MacOS)
     -v --verbose                    Enable verbose output
     --macos-universal               Create a universal .app bundle when both osx-x64 and osx-arm64 are specified
+    --publish-args <args>           Custom arguments to pass to dotnet publish (disables default flags)
     -h --help                       Show this help message
 
 Available runtime identifiers:
@@ -84,6 +85,7 @@ Examples:
     monopack -p ./src/MyGame.Desktop.csproj -e MyGame -o ./artifacts/builds -r win-x64 -r osx-x64 -r osx-arm64 -r linux-x64 -i ./Info.plist -c ./Icon.icns
     monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids win-x64,linux-x64,osx-x64,osx-arm64 -i ./Info.plist -c ./Icon.icns
     monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids osx-x64,osx-arm64 -i ./Info.plist -c ./Icon.icns --macos-universal
+    monopack -p ./src/MyGame.csproj --publish-args "-p:PublishAot=true"
 ```
 
 > [!IMPORTANT]

--- a/src/MonoPack/Builders/IPlatformBuilder.cs
+++ b/src/MonoPack/Builders/IPlatformBuilder.cs
@@ -9,5 +9,6 @@ internal interface IPlatformBuilder
     /// <param name="rid">Runtime identifier for the target platform.</param>
     /// <param name="executableName">Optional custom name for the executable.</param>
     /// <param name="verbose">Indicates whether to display verbose output.</param>
-    void Build(string projectPath, string outputDir, string rid, string? executableName, bool verbose);
+    /// <param name="publishArgs">Custom arguments to pass to dotnet publish. When specified, default flags are not applied.</param>
+    void Build(string projectPath, string outputDir, string rid, string? executableName, bool verbose, string? publishArgs);
 }

--- a/src/MonoPack/MonoPack.csproj
+++ b/src/MonoPack/MonoPack.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <Version>2.0.2</Version>
     <IsPackable>true</IsPackable>
     <PackageId>MonoPack</PackageId>

--- a/src/MonoPack/MonoPackService.cs
+++ b/src/MonoPack/MonoPackService.cs
@@ -54,10 +54,10 @@ internal sealed class MonoPackService
             Console.WriteLine("Building universal macOS bundle (osx-x64 + osx-arm64)");
 
             IPlatformBuilder x64Builder = PlatformBuilderFactory.CreateBuilder("osx-x64");
-            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, _options.VerboseOutput);
+            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
 
             IPlatformBuilder arm64Builder = PlatformBuilderFactory.CreateBuilder("osx-arm64");
-            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, _options.VerboseOutput);
+            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
 
             // Create universal package
             UniversalMacOSPackager packager = new UniversalMacOSPackager(_options.InfoPlistPath!, _options.IcnsPath!, x64BuildDir, arm64BuildDir);
@@ -116,7 +116,7 @@ internal sealed class MonoPackService
         {
             // Build the project for the specified runtime
             IPlatformBuilder builder = PlatformBuilderFactory.CreateBuilder(rid);
-            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, _options.VerboseOutput);
+            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
 
             // Package the build artifacts
             IPlatformPackager packager = PlatformPackagerFactory.CreatePackager(rid, _options.InfoPlistPath, _options.IcnsPath);

--- a/src/MonoPack/Options.cs
+++ b/src/MonoPack/Options.cs
@@ -30,7 +30,13 @@ internal sealed class Options
     public bool VerboseOutput { get; set; }
 
     /// <summary>Indicates whether to create a universal macOS .app bundle when both osx-x64 and osx-arm64 are specified.</summary>
-    public bool MacOSUniversal {get; set;}
+    public bool MacOSUniversal { get; set; }
+
+    /// <summary>
+    /// Gets or Sets additional arguments to pass to dotnet publish.
+    /// When specified, default publish flags are automatically disabled.
+    /// </summary>
+    public string? PublishArgs { get; set; }
 
     /// <summary>Validates and configures the MonoPack options.</summary>
     public void Validate()
@@ -273,6 +279,13 @@ internal sealed class Options
                     options.MacOSUniversal = true;
                     break;
 
+                case "--publish-args":
+                    if (i + 1 < args.Length)
+                    {
+                        options.PublishArgs = args[++i];
+                    }
+                    break;
+
                 case "-h":
                 case "--help":
                     DisplayHelp();
@@ -309,6 +322,7 @@ internal sealed class Options
                 -z --zip                        Use zip for packaging instead of tar.gz (only for Linux and MacOS)
                 -v --verbose                    Enable verbose output
                 --macos-universal               Create a universal .app bundle when both osx-x64 and osx-arm64 are specified
+                --publish-args <args>           Custom arguments to pass to dotnet publish (disables default flags)
                 -h --help                       Show this help message
 
             Available runtime identifiers:
@@ -340,6 +354,7 @@ internal sealed class Options
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -r win-x64 -r osx-x64 -r osx-arm64 -r linux-x64 -i ./Info.plist -c ./Icon.icns
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids win-x64,osx-x64,osx-arm64,linux-x64 -i ./Info.plist -c ./Icon.icns
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids osx-x64,osx-arm64 -i ./Info.plist -c ./Icon.icns --macos-universal
+                monopack -p ./src/MyGame.csproj --publish-args "-p:PublishAot=true --self-contained"
             """
         );
     }

--- a/src/MonoPack/Options.cs
+++ b/src/MonoPack/Options.cs
@@ -354,7 +354,7 @@ internal sealed class Options
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -r win-x64 -r osx-x64 -r osx-arm64 -r linux-x64 -i ./Info.plist -c ./Icon.icns
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids win-x64,osx-x64,osx-arm64,linux-x64 -i ./Info.plist -c ./Icon.icns
                 monopack -p ./src/MyGame.csproj -o ./artifacts/builds -rids osx-x64,osx-arm64 -i ./Info.plist -c ./Icon.icns --macos-universal
-                monopack -p ./src/MyGame.csproj --publish-args "-p:PublishAot=true --self-contained"
+                monopack -p ./src/MyGame.csproj --publish-args "-p:PublishAot=true"
             """
         );
     }


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
Removes the hard coded publish args for tier compilation, ready-to-run, and publish single file. Tiered compilation and ready-to-run are set by default monogame templates already and forcing single file means users cannot do a native aot build.

Users can now specify the publish args to pass to the dotnet publish command by using the `--publish-args` flag.  For example

```
monopack -p ./src/MyGame.csproj --publish-args "-p:PublishAot=true"
```

## Related Issue Ticket Numbers
- Closes #11 