### PR TITLE
Compare exectuable name suggested with actual parsed name before specifying MSBuild attributes

### DIFF
--- a/src/MonoPack/Builders/IPlatformBuilder.cs
+++ b/src/MonoPack/Builders/IPlatformBuilder.cs
@@ -7,8 +7,9 @@ internal interface IPlatformBuilder
     /// <param name="projectPath">Path to the project file.</param>
     /// <param name="outputDir">Directory to place build artifacts.</param>
     /// <param name="rid">Runtime identifier for the target platform.</param>
-    /// <param name="executableName">Optional custom name for the executable.</param>
+    /// <param name="suggestedExecutableName">Optional custom name for the executable.</param>
+    /// <param name="actualExecutableName">The parsed executable name.</param>
     /// <param name="verbose">Indicates whether to display verbose output.</param>
     /// <param name="publishArgs">Custom arguments to pass to dotnet publish. When specified, default flags are not applied.</param>
-    void Build(string projectPath, string outputDir, string rid, string? executableName, bool verbose, string? publishArgs);
+    void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string actualExecutableName, bool verbose, string? publishArgs);
 }

--- a/src/MonoPack/Builders/IPlatformBuilder.cs
+++ b/src/MonoPack/Builders/IPlatformBuilder.cs
@@ -7,9 +7,9 @@ internal interface IPlatformBuilder
     /// <param name="projectPath">Path to the project file.</param>
     /// <param name="outputDir">Directory to place build artifacts.</param>
     /// <param name="rid">Runtime identifier for the target platform.</param>
-    /// <param name="suggestedExecutableName">Optional custom name for the executable.</param>
-    /// <param name="actualExecutableName">The parsed executable name.</param>
+    /// <param name="suggestedExecutableName">User-specified custom name for the exeutable (from -e flag).</param>
+    /// <param name="defaultExecutableName">Default executable name from the project's MSBUILD configuration..</param>
     /// <param name="verbose">Indicates whether to display verbose output.</param>
     /// <param name="publishArgs">Custom arguments to pass to dotnet publish. When specified, default flags are not applied.</param>
-    void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string actualExecutableName, bool verbose, string? publishArgs);
+    void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string defaultExecutableName, bool verbose, string? publishArgs);
 }

--- a/src/MonoPack/Builders/PlatformBuilder.cs
+++ b/src/MonoPack/Builders/PlatformBuilder.cs
@@ -9,23 +9,23 @@ internal abstract class PlatformBuilder : IPlatformBuilder
     /// <param name="projectPath">Path to the project file.</param>
     /// <param name="outputDir">Directory to place build artifacts.</param>
     /// <param name="rid">Runtime identifier for the target platform.</param>
-    /// <param name="suggestedExecutableName">Optional custom name for the executable.</param>
-    /// <param name="actualExecutableName">The parsed executable name.</param>
+    /// <param name="suggestedExecutableName">User-specified custom name for the exeutable (from -e flag).</param>
+    /// <param name="defaultExecutableName">Default executable name from the project's MSBUILD configuration..</param>
     /// <param name="verbose">Indicates whether to display verbose output.</param>
     /// <param name="publishArgs">Custom arguments to pass to dotnet publish. When specified, default flags are not applied.</param>
-    public void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string actualExecutableName, bool verbose, string? publishArgs)
+    public void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string defaultExecutableName, bool verbose, string? publishArgs)
     {
         Console.WriteLine($"Building {rid}");
 
         string arguments = $"publish \"{projectPath}\" -c Release -r {rid} --self-contained ";
 
-        if(!string.IsNullOrEmpty(publishArgs))
+        if (!string.IsNullOrEmpty(publishArgs))
         {
             arguments += $"{publishArgs} ";
         }
 
         // Use custom assembly name if executable name was given
-        if(!string.IsNullOrEmpty(suggestedExecutableName) && (suggestedExecutableName != actualExecutableName))
+        if (!string.IsNullOrEmpty(suggestedExecutableName) && (suggestedExecutableName != defaultExecutableName))
         {
             arguments += $"-p:AssemblyName=\"{suggestedExecutableName}\" ";
         }

--- a/src/MonoPack/Builders/PlatformBuilder.cs
+++ b/src/MonoPack/Builders/PlatformBuilder.cs
@@ -5,14 +5,15 @@ namespace MonoPack.Builders;
 /// <summary>Base implementation for platform-specific build strategies</summary>
 internal abstract class PlatformBuilder : IPlatformBuilder
 {
-    /// <summary>Builds the application using dotnet publish.</summary>
+    /// <summary>Builds the application for a specific runtime identifier.</summary>
     /// <param name="projectPath">Path to the project file.</param>
     /// <param name="outputDir">Directory to place build artifacts.</param>
     /// <param name="rid">Runtime identifier for the target platform.</param>
-    /// <param name="executableName">Optional custom name for the executable.</param>
+    /// <param name="suggestedExecutableName">Optional custom name for the executable.</param>
+    /// <param name="actualExecutableName">The parsed executable name.</param>
     /// <param name="verbose">Indicates whether to display verbose output.</param>
     /// <param name="publishArgs">Custom arguments to pass to dotnet publish. When specified, default flags are not applied.</param>
-    public void Build(string projectPath, string outputDir, string rid, string? executableName, bool verbose, string? publishArgs)
+    public void Build(string projectPath, string outputDir, string rid, string? suggestedExecutableName, string actualExecutableName, bool verbose, string? publishArgs)
     {
         Console.WriteLine($"Building {rid}");
 
@@ -24,9 +25,9 @@ internal abstract class PlatformBuilder : IPlatformBuilder
         }
 
         // Use custom assembly name if executable name was given
-        if(!string.IsNullOrEmpty(executableName))
+        if(!string.IsNullOrEmpty(suggestedExecutableName) && (suggestedExecutableName != actualExecutableName))
         {
-            arguments += $"-p:AssemblyName=\"{executableName}\" ";
+            arguments += $"-p:AssemblyName=\"{suggestedExecutableName}\" ";
         }
 
         arguments += $"-o \"{outputDir}\"";

--- a/src/MonoPack/MonoPackService.cs
+++ b/src/MonoPack/MonoPackService.cs
@@ -119,10 +119,10 @@ internal sealed class MonoPackService
             Console.WriteLine("Building universal macOS bundle (osx-x64 + osx-arm64)");
 
             IPlatformBuilder x64Builder = PlatformBuilderFactory.CreateBuilder("osx-x64");
-            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
+            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             IPlatformBuilder arm64Builder = PlatformBuilderFactory.CreateBuilder("osx-arm64");
-            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
+            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             // Create universal package
             UniversalMacOSPackager packager = new UniversalMacOSPackager(_options.InfoPlistPath!, _options.IcnsPath!, x64BuildDir, arm64BuildDir, actualExecutableName);
@@ -183,7 +183,7 @@ internal sealed class MonoPackService
         {
             // Build the project for the specified runtime
             IPlatformBuilder builder = PlatformBuilderFactory.CreateBuilder(rid);
-            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, _options.VerboseOutput, _options.PublishArgs);
+            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             // Package the build artifacts
             IPlatformPackager packager = PlatformPackagerFactory.CreatePackager(rid, _options.InfoPlistPath, _options.IcnsPath);

--- a/src/MonoPack/MonoPackService.cs
+++ b/src/MonoPack/MonoPackService.cs
@@ -41,15 +41,8 @@ internal sealed class MonoPackService
         }
     }
 
-    private string GetActualExecutableName(string? rid = null)
+    private string GetDefaultExecutableName(string? rid = null)
     {
-        // If user specified a custom executable name via -e option, use that
-        // (the build command will pass this as -p:AssemblyName)
-        if(!string.IsNullOrEmpty(_options.ExecutableFileName))
-        {
-            return _options.ExecutableFileName;
-        }
-
         // Query MSBuild for the evaluated AssemblyName property
         try
         {
@@ -57,7 +50,7 @@ internal sealed class MonoPackService
             // during dotnet publish. This will catch any conditionals that
             // may be set inside the csproj or props/targets files
             string arguments = $"msbuild \"{_options.ProjectPath}\" -nologo -getProperty:AssemblyName -p:Configuration=Release";
-            if(!string.IsNullOrEmpty(rid))
+            if (!string.IsNullOrEmpty(rid))
             {
                 arguments += $" -p:RuntimeIdentifier={rid}";
             }
@@ -72,27 +65,27 @@ internal sealed class MonoPackService
                 CreateNoWindow = true
             };
 
-            using Process process = new Process() {StartInfo = startInfo};
+            using Process process = new Process() { StartInfo = startInfo };
             process.Start();
 
             string output = process.StandardOutput.ReadToEnd().Trim();
-            string error= process.StandardError.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
 
             process.WaitForExit();
 
-            if(process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+            if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
             {
                 return output;
             }
 
-            if(_options.VerboseOutput && !string.IsNullOrEmpty(error))
+            if (_options.VerboseOutput && !string.IsNullOrEmpty(error))
             {
                 Console.WriteLine($"Warning: Failed to get AssemblyName from MSBuild: {error}");
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(_options.VerboseOutput)
+            if (_options.VerboseOutput)
             {
                 Console.WriteLine($"Warning: Could not query MSBuild for AssemblyName: {ex.Message}");
             }
@@ -102,6 +95,16 @@ internal sealed class MonoPackService
         return Path.GetFileNameWithoutExtension(_options.ProjectPath);
     }
 
+    private string GetEffectiveExecutableName(string? rid = null)
+    {
+        if (!string.IsNullOrEmpty(_options.ExecutableFileName))
+        {
+            return _options.ExecutableFileName;
+        }
+
+        return GetDefaultExecutableName(rid);
+    }
+
     private void PackageUniversalMacOS()
     {
         // Create intermediate directory for build outputs
@@ -109,7 +112,8 @@ internal sealed class MonoPackService
         string x64BuildDir = Path.Combine(tempDir, "osx-x64");
         string arm64BuildDir = Path.Combine(tempDir, "osx-arm64");
 
-        string actualExecutableName = GetActualExecutableName("osx-x64");
+        string defaultExecutableName = GetDefaultExecutableName("osx-x64");
+        string effectiveExecutablName = GetEffectiveExecutableName("osx-x64");
 
         string projectName = Path.GetFileNameWithoutExtension(_options.ProjectPath);
 
@@ -119,30 +123,30 @@ internal sealed class MonoPackService
             Console.WriteLine("Building universal macOS bundle (osx-x64 + osx-arm64)");
 
             IPlatformBuilder x64Builder = PlatformBuilderFactory.CreateBuilder("osx-x64");
-            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
+            x64Builder.Build(_options.ProjectPath, x64BuildDir, "osx-x64", _options.ExecutableFileName, defaultExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             IPlatformBuilder arm64Builder = PlatformBuilderFactory.CreateBuilder("osx-arm64");
-            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
+            arm64Builder.Build(_options.ProjectPath, arm64BuildDir, "osx-arm64", _options.ExecutableFileName, defaultExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             // Create universal package
-            UniversalMacOSPackager packager = new UniversalMacOSPackager(_options.InfoPlistPath!, _options.IcnsPath!, x64BuildDir, arm64BuildDir, actualExecutableName);
+            UniversalMacOSPackager packager = new UniversalMacOSPackager(_options.InfoPlistPath!, _options.IcnsPath!, x64BuildDir, arm64BuildDir, effectiveExecutablName);
 
             packager.Package(string.Empty, _options.OutputDirectory, projectName, _options.ExecutableFileName, "universal", _options.UseZipCompression);
 
             // Process remaining non-macOS runtime identifiers
-            foreach(string rid in _options.RuntimeIdentifiers)
+            foreach (string rid in _options.RuntimeIdentifiers)
             {
-                if(rid != "osx-x64" && rid != "osx-arm64")
+                if (rid != "osx-x64" && rid != "osx-arm64")
                 {
                     PackageForRuntime(rid);
                 }
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Console.Error.WriteLine($"Error creating universal macOS package: {ex.Message}");
 
-            if(_options.VerboseOutput)
+            if (_options.VerboseOutput)
             {
                 Console.Error.WriteLine(ex.StackTrace);
             }
@@ -151,15 +155,15 @@ internal sealed class MonoPackService
         finally
         {
             // Clean up intermediate directory
-            if(Directory.Exists(tempDir))
+            if (Directory.Exists(tempDir))
             {
                 try
                 {
                     Directory.Delete(tempDir, recursive: true);
                 }
-                catch(IOException ex)
+                catch (IOException ex)
                 {
-                    if(_options.VerboseOutput)
+                    if (_options.VerboseOutput)
                     {
                         Console.WriteLine($"Warning: Failed to clean up temporary directory {tempDir}: {ex.Message}");
                     }
@@ -174,7 +178,8 @@ internal sealed class MonoPackService
         string tempDir = Path.Combine(Path.GetTempPath(), "MonoPack", Guid.NewGuid().ToString());
         string buildOutputDir = Path.Combine(tempDir, rid);
 
-        string actualExecutableName = GetActualExecutableName(rid);
+        string defaultExecutableName = GetDefaultExecutableName(rid);
+        string effectiveExecutablName = GetEffectiveExecutableName(rid);
 
         // Extract project name from the project path
         string projectName = Path.GetFileNameWithoutExtension(_options.ProjectPath);
@@ -183,11 +188,11 @@ internal sealed class MonoPackService
         {
             // Build the project for the specified runtime
             IPlatformBuilder builder = PlatformBuilderFactory.CreateBuilder(rid);
-            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, actualExecutableName, _options.VerboseOutput, _options.PublishArgs);
+            builder.Build(_options.ProjectPath, buildOutputDir, rid, _options.ExecutableFileName, defaultExecutableName, _options.VerboseOutput, _options.PublishArgs);
 
             // Package the build artifacts
             IPlatformPackager packager = PlatformPackagerFactory.CreatePackager(rid, _options.InfoPlistPath, _options.IcnsPath);
-            packager.Package(buildOutputDir, _options.OutputDirectory, projectName, actualExecutableName, rid, _options.UseZipCompression);
+            packager.Package(buildOutputDir, _options.OutputDirectory, projectName, effectiveExecutablName, rid, _options.UseZipCompression);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
When specifying the assembly name using `-e` flag, if the assembly name and the actual project itself were the same name, using the `-p:AssemblyName` MSBUILD flag would throw an error stating the names were ambiguous.  Change updates so that the MSBUILD flag is only used if the names are distinct.

## Related Issue Ticket Numbers
- None